### PR TITLE
Enhance: validate pasted urls by constructing a URL() object

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -67,15 +67,20 @@ function handleMessage(message, time) {
           const transfer = event.clipboardData;
           var contents = transfer.getData("text");
 
-          var expression = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i;
-
-          var regex = new RegExp(expression);
+          function isUrlValid(string) {
+            try {
+              new URL(string);
+              return true;
+            } catch (typeError) {
+              return false;
+            }
+          }
 
           var lines = contents.split(/\r?\n/);
           // go through each line and 1) look for urls 2) get rid of dupes
           var links = [];
           for (let line of lines) {
-            if (line.match(regex)) {
+            if (isUrlValid(line)) {
               //sometimes the url and the title is the same...
               //don't want to open multiple instance of the same url
               //check for and ignore duplicates


### PR DESCRIPTION
Hello! Thanks for your great work.

This add-on works fine in many cases, but sometimes gets stuck. I'm using the version of [0.0.9](https://github.com/charlesbrandt/copy_all_tabs/tree/683bd43bc5d36e057b2507616ef4084737ca456d) (git tag not found, though).

<br>

Here are the URLs I copied from Firefox via this add-on and wanted to paste back. All of them are Wikipedia pages of Richmond, Virginia, USA:

> https://en.wikipedia.org/wiki/Richmond,_Virginia
> Richmond, Virginia - Wikipedia
> 
> https://uk.wikipedia.org/wiki/%D0%A0%D0%B8%D1%87%D0%BC%D0%BE%D0%BD%D0%B4_(%D0%92%D1%96%D1%80%D0%B4%D0%B6%D0%B8%D0%BD%D1%96%D1%8F)
> Ричмонд (Вірджинія) — Вікіпедія
> https://ru.wikipedia.org/wiki/%D0%A0%D0%B8%D1%87%D0%BC%D0%BE%D0%BD%D0%B4_(%D0%92%D0%B8%D1%80%D0%B3%D0%B8%D0%BD%D0%B8%D1%8F)
> Ричмонд (Виргиния) — Википедия
> https://ko.wikipedia.org/wiki/%EB%A6%AC%EC%B9%98%EB%A8%BC%EB%93%9C_(%EB%B2%84%EC%A7%80%EB%8B%88%EC%95%84%EC%A3%BC)
> 리치먼드 (버지니아주) - 위키백과, 우리 모두의 백과사전
> https://ja.wikipedia.org/wiki/%E3%83%AA%E3%83%83%E3%83%81%E3%83%A2%E3%83%B3%E3%83%89_(%E3%83%AD%E3%83%B3%E3%83%89%E3%83%B3)
> リッチモンド (ロンドン) - Wikipedia
> https://zh.wikipedia.org/wiki/%E9%87%8C%E5%A3%AB%E6%BB%A1_(%E5%BC%97%E5%90%89%E5%B0%BC%E4%BA%9A%E5%B7%9E)
> 里士满 (弗吉尼亚州) - 维基百科，自由的百科全书

Then, I got:

```console
Uncaught (in promise) Error: too much recursion                undefined
    apply self-hosted:2736
    applySafeWithoutClone resource://gre/modules/ExtensionCommon.jsm:622
    wrapPromise resource://gre/modules/ExtensionCommon.jsm:870
    (Async: promise callback)
    wrapPromise resource://gre/modules/ExtensionCommon.jsm:831
    wrapPromise resource://gre/modules/ExtensionCommon.jsm:830
    callAsyncFunction resource://gre/modules/ExtensionCommon.jsm:1067
    callAsyncFunction resource://gre/modules/ExtensionChild.jsm:730
    callAndLog resource://gre/modules/ExtensionChild.jsm:701
    callAsyncFunction resource://gre/modules/ExtensionChild.jsm:729
    stub resource://gre/modules/Schemas.jsm:2859
    <anonymous> moz-extension://049d025e-74bf-4156-b09f-ce1cca2db8f3/tabs.js:125
    (Async: EventListener.handleEvent)
    <anonymous> moz-extension://049d025e-74bf-4156-b09f-ce1cca2db8f3/tabs.js:94
```

`moz-extension://049d025e-74bf-4156-b09f-ce1cca2db8f3/tabs.js:125` is:

https://github.com/charlesbrandt/copy_all_tabs/blob/683bd43bc5d36e057b2507616ef4084737ca456d/src/tabs.js#L125

<br>

By setting breakpoints, I found it was stuck at the RegExp operation:

https://github.com/charlesbrandt/copy_all_tabs/blob/683bd43bc5d36e057b2507616ef4084737ca456d/src/background.js#L78

The PCRE2 engine of [regex101](https://regex101.com/) said there is a [catastrophic backtracking](https://www.regular-expressions.info/catastrophic.html) when processing URLs with the massive RegExp:

```RegExp
/\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))/i
```

I tried to fix it by modifying it, but I gave up due to its complexity.

After a while, I found [Check if a JavaScript string is a URL - Stack Overflow](https://stackoverflow.com/q/5717093) and the answer with the highest score mentions the [```URL``` constructor](https://developer.mozilla.org/docs/Web/API/URL). Since the ```URL``` class is implemented by Firefox <sup>\[1\]</sup>, I think all URLs from Firefox should be correctly handled by Firefox itself.

\[1\]: https://searchfox.org/mozilla-central/rev/76ccfc801e6b736c844cde3fddeab7a748fc8515/dom/url/URL.cpp#69-92

<br>

So, the ```URL``` constructor works for me. I make this PR and hope it can solve the problem with URL validation and simplify the code.


